### PR TITLE
Cleanups and minor features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 shirka
 tmp/*
+*.o

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,10 @@
-.SUFFIXES: .c .o
+CFLAGS+=-std=c99 -pedantic -Wall -Wextra -Wdeclaration-after-statement
 
+shirka: Makefile
 shirka: shirka.c shirka.h env.o objects.o parser.o intrinsics.c
-	$(CC) -std=c99 -pedantic -Wall -Wextra -Wdeclaration-after-statement \
-	-o shirka shirka.c env.o objects.o parser.o
+	$(CC) $(CFLAGS) -o shirka shirka.c env.o objects.o parser.o
 
+.PHONY: clean
 clean:
-	rm *.o
-
-.c.o:
-	$(CC) -std=c99 -pedantic -Wall -Wextra -Wdeclaration-after-statement \
-	-o $@ -c $<
+	rm -f *.o
+	rm -f shirka

--- a/env.c
+++ b/env.c
@@ -11,7 +11,7 @@ skO *skE_stackPop (skE *env)
 	skO *obj;
 
 	if (env->stack == NULL) {
-		printf("PANIC! Tried to pop object but stack is empty.\n");
+		fprintf(stderr, "PANIC! Tried to pop object but stack is empty.\n");
 		env->panic = 1;
 		longjmp(env->jmp, 1);
 	}
@@ -139,7 +139,7 @@ void skE_defOperation (skE *env, skO *sym, skO *obj)
 	skO_checkType(obj, SKO_LIST);
 
 	if (scope_find_current(env, sym) != NULL) {
-		printf("PANIC! Can't redefine reserved operation %s.\n", sym->data.sym->name);
+		fprintf(stderr, "PANIC! Can't redefine reserved operation %s.\n", sym->data.sym->name);
 		env->panic = 1;
 		longjmp(env->jmp, 1);
 	}
@@ -165,13 +165,13 @@ void skE_undef (skE *env, skO *sym)
 	r = scope_find_current(env, sym);
 
 	if (r == NULL) {
-		printf("PANIC! Reserved object not found in current scope.\n");
+		fprintf(stderr, "PANIC! Reserved object not found in current scope.\n");
 		env->panic = 1;
 		longjmp(env->jmp, 1);
 	}
 
 	if (r->kind != KIND_OBJECT) {
-		printf("PANIC! Expected object, got native or operation.\n");
+		fprintf(stderr, "PANIC! Expected object, got native or operation.\n");
 		env->panic = 1;
 		longjmp(env->jmp, 1);
 	}
@@ -278,7 +278,7 @@ tail:
 		case SKO_SYMBOL:
 			r = scope_find(env, tok);
 			if (r == NULL) {
-				printf("PANIC! Not found: %s\n", (tok->data.sym)->name);
+				fprintf(stderr, "PANIC! Not found: %s\n", (tok->data.sym)->name);
 				env->panic = 1;
 				longjmp(env->jmp, 1);
 			}
@@ -326,7 +326,7 @@ tail:
 				#endif
 				break;
 			default:
-				printf("PANIC! Internal kind error.\n");
+				fprintf(stderr, "PANIC! Internal kind error.\n");
 				longjmp(env->jmp, 1);
 			}
 
@@ -340,7 +340,7 @@ tail:
 			skE_stackPush(env, tok);
 			break;
 		default:
-			printf("PANIC! Internal type error.\n");
+			fprintf(stderr, "PANIC! Internal type error.\n");
 			env->panic = 1;
 			longjmp(env->jmp, 1);
 		}
@@ -360,13 +360,13 @@ skO *skO_loadParse (char *path)
 	jmp_buf jmp;
 
 	if (setjmp(jmp)) {
-		printf("Syntax error in file %s\n", path);
+		fprintf(stderr, "Syntax error in file %s\n", path);
 		exit(EXIT_FAILURE);
 	}
 
 	f = fopen(path, "rb");
 	if (f == NULL) {
-		printf("INTERPRETER ERROR! Could not open file.\n");
+		fprintf(stderr, "INTERPRETER ERROR! Could not open file.\n");
 		exit(EXIT_FAILURE);
 	}
 	/* get file size */

--- a/env.c
+++ b/env.c
@@ -366,7 +366,7 @@ skO *skO_loadParse (char *path)
 
 	f = fopen(path, "rb");
 	if (f == NULL) {
-		fprintf(stderr, "INTERPRETER ERROR! Could not open file.\n");
+		fprintf(stderr, "INTERPRETER ERROR! Could not open file %s.\n", path);
 		exit(EXIT_FAILURE);
 	}
 	/* get file size */

--- a/env.c
+++ b/env.c
@@ -74,7 +74,7 @@ reserved *scope_find_current (skE *env, skO *sym)
 
 skE *skE_new (void)
 {
-	skE *env = (skE *)malloc(sizeof(skE));
+	skE *env = malloc(sizeof(skE));
 	env->stack = NULL;
 	env->scope = NULL;
 	env->panic = 0;
@@ -99,7 +99,7 @@ void skE_defNative (skE *env, char *name, skE_natOp *native)
 	reserved *slot;
 	skO *obj = skO_symbol_new(name);
 
-	slot              = (reserved *)malloc(sizeof(reserved));
+	slot              = malloc(sizeof(reserved));
 	slot->next        = env->scope->first_def;
 	slot->sym         = obj->data.sym;
 	slot->kind        = KIND_NATIVE;
@@ -120,7 +120,7 @@ void skE_defObject (skE *env, skO *sym, skO *obj)
 		/* Release previously defined object? */
 	}
 
-	slot           = (reserved *)malloc(sizeof(reserved));
+	slot           = malloc(sizeof(reserved));
 	slot->next     = scope_get(env)->first_def;
 	slot->sym      = sym->data.sym;
 	slot->kind     = KIND_OBJECT;
@@ -144,7 +144,7 @@ void skE_defOperation (skE *env, skO *sym, skO *obj)
 		longjmp(env->jmp, 1);
 	}
 
-	slot           = (reserved *)malloc(sizeof(reserved));
+	slot           = malloc(sizeof(reserved));
 	slot->next     = scope_get(env)->first_def;
 	slot->sym      = sym->data.sym;
 	slot->kind     = KIND_OPERATION;
@@ -194,7 +194,7 @@ void skE_undef (skE *env, skO *sym)
 
 void skE_scopePush (skE *env)
 {
-	context *ct = (context *)malloc(sizeof(context));
+	context *ct = malloc(sizeof(context));
 	ct->parent = env->scope;
 	ct->first_def = NULL;
 	env->scope = ct;
@@ -372,7 +372,7 @@ skO *skO_loadParse (char *path)
 	f_size = ftell(f);
 	fseek(f, 0, SEEK_SET);
 	/* copy source into string */
-	src = (char *)malloc(f_size);
+	src = malloc(f_size);
 	fread(src, f_size, 1, f);
 	src[f_size] = 0;
 	fclose(f);

--- a/intrinsics.c
+++ b/intrinsics.c
@@ -335,7 +335,7 @@ SK_INTRINSIC skI_parse (skE *env)
 		node = node->next;
 	}
 
-	str = (char *)malloc(count);
+	str = malloc(count);
 
 	node = list->data.list;
 	while (node) {

--- a/intrinsics.c
+++ b/intrinsics.c
@@ -89,7 +89,7 @@ SK_INTRINSIC skI_print (skE *env)
 		}
 		break;
 	default:
-		printf("PANIC! Internal type error.\n");
+		fprintf(stderr, "PANIC! Internal type error.\n");
 		env->panic = 1;
 		longjmp(env->jmp, 1);
 	}
@@ -389,7 +389,7 @@ SK_INTRINSIC skI_eql (skE *env)
 	if (l->tag == r->tag) {
 		switch (l->tag) {
 		case SKO_LIST:
-			printf("PANIC! Equality testing not yet implemented for lists.\n");
+			fprintf(stderr, "PANIC! Equality testing not yet implemented for lists.\n");
 			env->panic = 1;
 			longjmp(env->jmp, 1);
 		default:
@@ -505,7 +505,7 @@ SK_INTRINSIC skI_type (skE *env)
 		sym = skO_symbol_new("Boolean");
 		break;
 	default:
-		printf("PANIC! Internal type error: %i\n", obj->tag);
+		fprintf(stderr, "PANIC! Internal type error: %i\n", obj->tag);
 		env->panic = 1;
 		longjmp(env->jmp, 1);
 	}

--- a/intrinsics.c
+++ b/intrinsics.c
@@ -11,7 +11,7 @@ void print_list (skO *list)
 {
 	skO *node = list->data.list;
 
-	while (node != NULL) {
+	while (node) {
 		switch (node->tag) {
 		case SKO_QSYMBOL:
 		case SKO_SYMBOL:
@@ -330,7 +330,7 @@ SK_INTRINSIC skI_parse (skE *env)
 	skO_checkType(list, SKO_LIST);
 
 	node = list->data.list;
-	while (node != NULL) {
+	while (node) {
 		count++;
 		node = node->next;
 	}
@@ -338,7 +338,7 @@ SK_INTRINSIC skI_parse (skE *env)
 	str = (char *)malloc(count);
 
 	node = list->data.list;
-	while (node != NULL) {
+	while (node) {
 		str[i] = node->data.character;
 		i++;
 		node = node->next;
@@ -415,7 +415,7 @@ SK_INTRINSIC skI_length (skE *env)
 	skO *list = skE_stackPop(env);
 	skO *node = list->data.list;
 
-	while (node != NULL) {
+	while (node) {
 		len++;
 		node = node->next;
 	}
@@ -465,7 +465,7 @@ SK_INTRINSIC skI_with (skE *env)
 	skO_checkType(fname, SKO_LIST);
 	skchar = fname->data.list;
 
-	while (skchar != NULL) {
+	while (skchar) {
 		buffer[i] = skchar->data.character;
 		skchar = skchar->next;
 		i++;

--- a/objects.c
+++ b/objects.c
@@ -59,7 +59,7 @@ skO *skO_clone (skO *obj)
 
 		break;
 	default:
-		printf("Internal type error.\n");
+		fprintf(stderr, "Internal type error.\n");
 		exit(EXIT_FAILURE);
 	}
 
@@ -88,7 +88,7 @@ void skO_free (skO *obj)
 		free (obj);
 		break;
 	default:
-		printf("Internal type error.\n");
+		fprintf(stderr, "Internal type error.\n");
 		exit(EXIT_FAILURE);
 		break;
 	}
@@ -195,7 +195,7 @@ const char *tystr (size_t i)
 	case SKO_SYMBOL:    return SYMBOL_AS_STRING;
 	case SKO_LIST:      return LIST_AS_STRING;
 	default:
-		printf("Internal type error.\n");
+		fprintf(stderr, "Internal type error.\n");
 		exit(EXIT_FAILURE);
 	}
 }
@@ -205,7 +205,7 @@ void skO_checkType(skO *obj, skO_t type)
 	if (obj->tag == type)
 		return;
 
-	printf("INTERPRETER ERROR! Expected `%s' but got `%s'.\n",
+	fprintf(stderr, "INTERPRETER ERROR! Expected `%s' but got `%s'.\n",
 		tystr(type), tystr(obj->tag));
 	exit(EXIT_FAILURE);
 }

--- a/objects.c
+++ b/objects.c
@@ -19,7 +19,7 @@ symbol *symbol_id_from_string (char *str)
 		sym = sym->next;
 	}
 
-	sym = (symbol *)malloc(sizeof(symbol));
+	sym = malloc(sizeof(symbol));
 	strcpy(sym->name, str);
 	sym->next = symbol_list;
 
@@ -35,7 +35,7 @@ skO *skO_clone (skO *obj)
 	skO *iter;
 	skO *child_copy;
 
-	copy       = (skO *)malloc(sizeof(skO));
+	copy       = malloc(sizeof(skO));
 	copy->next = NULL;
 	copy->tag  = obj->tag;
 
@@ -96,7 +96,7 @@ void skO_free (skO *obj)
 
 skO *skO_number_new (double d)
 {
-	skO *obj = (skO *)malloc(sizeof(skO));
+	skO *obj = malloc(sizeof(skO));
 
 	obj->next        = NULL;
 	obj->tag         = SKO_NUMBER;
@@ -107,7 +107,7 @@ skO *skO_number_new (double d)
 
 skO *skO_boolean_new (int b)
 {
-	skO *obj = (skO *)malloc(sizeof(skO));
+	skO *obj = malloc(sizeof(skO));
 
 	obj->next         = NULL;
 	obj->tag          = SKO_BOOLEAN;
@@ -118,7 +118,7 @@ skO *skO_boolean_new (int b)
 
 skO *skO_character_new (char c)
 {
-	skO *obj = (skO *)malloc(sizeof(skO));
+	skO *obj = malloc(sizeof(skO));
 
 	obj->next           = NULL;
 	obj->tag            = SKO_CHARACTER;
@@ -129,7 +129,7 @@ skO *skO_character_new (char c)
 
 skO *skO_quoted_symbol_new (char *a)
 {
-	skO *obj = (skO *)malloc(sizeof(skO));
+	skO *obj = malloc(sizeof(skO));
 
 	obj->next     = NULL;
 	obj->tag      = SKO_QSYMBOL;
@@ -140,7 +140,7 @@ skO *skO_quoted_symbol_new (char *a)
 
 skO *skO_symbol_new (char *a)
 {
-	skO *obj = (skO *)malloc(sizeof(skO));
+	skO *obj = malloc(sizeof(skO));
 
 	obj->next     = NULL;
 	obj->tag      = SKO_SYMBOL;
@@ -151,7 +151,7 @@ skO *skO_symbol_new (char *a)
 
 skO *skO_list_new (void)
 {
-	skO *obj = (skO *)malloc(sizeof(skO));
+	skO *obj = malloc(sizeof(skO));
 
 	obj->next      = NULL;
 	obj->tag       = SKO_LIST;

--- a/objects.c
+++ b/objects.c
@@ -11,7 +11,7 @@ symbol *symbol_id_from_string (char *str)
 {
 	symbol *sym = symbol_list;
 
-	while (sym != NULL) {
+	while (sym) {
 		if (strcmp(str, sym->name) == 0) {
 			goto symbol_found;
 		}
@@ -51,7 +51,7 @@ skO *skO_clone (skO *obj)
 		copy->data.list = NULL;
 
 		iter = obj->data.list;
-		while (iter != NULL) {
+		while (iter) {
 			child_copy = skO_clone(iter);
 			sk_list_append(copy, child_copy);
 			iter = iter->next;
@@ -74,7 +74,7 @@ void skO_free (skO *obj)
 	switch (obj->tag) {
 	case SKO_LIST:
 		node = obj->data.list;
-		while (node != NULL) {
+		while (node) {
 			next = node->next;
 
 			skO_free(node);
@@ -168,13 +168,13 @@ void sk_list_append (skO *list, skO *obj)
 
 	node = list->data.list;
 
-	if (node == NULL) {
-		list->data.list = obj;
-	} else {
-		while (node->next != NULL) {
+	if (node) {
+		while (node->next) {
 			node = node->next;
 		}
 		node->next = obj;
+	} else {
+		list->data.list = obj;
 	}
 }
 

--- a/parser.c
+++ b/parser.c
@@ -164,8 +164,17 @@ skO *parse_character (char **next, jmp_buf jmp)
 	if (*c == '\\') {
 		c++;
 		switch (*c) {
+		case '\\':
+			result = '\\';
+			break;
 		case 'n':
 			result = '\n';
+			break;
+		case 's':
+			result = ' ';
+			break;
+		case 't':
+			result = '\t';
 			break;
 		default:
 			FATAL("PANIC! Unknown escape sequence \\%c.\n", *c);

--- a/parser.c
+++ b/parser.c
@@ -29,6 +29,7 @@ To enable the printing of debug information, define the constant
 `SK_PARSER_DEBUG` when compiling the interpreter.
 */
 
+#include <ctype.h>
 #include <stdlib.h>
 #include <setjmp.h>
 #include "shirka.h"
@@ -43,24 +44,13 @@ To enable the printing of debug information, define the constant
 The following macros are used by token extractors as character categories.
 */
 
-#define LETTER_UP(c) (c >= 'A' && c <= 'Z')
+#define IDENTIFIER_START(c) (isalpha(c)                                      \
+	|| c == '*' || c == '+' || c == '-' || c == '/' || c == '<'          \
+	|| c == '=' || c == '>' || c == '^' || c == '!' || c == '&'          \
+	|| c == '.' || c == '?' || c == '|' || c == '~' || c == '$'          \
+	|| c == '%')
 
-#define LETTER_DOWN(c) (c >= 'a' && c <= 'z')
-
-#define LETTER(c) (LETTER_UP(c) || LETTER_DOWN(c) || c == '_')
-
-#define DIGIT(c) (c >= '0' && c <= '9')
-
-#define WHITESPACE(c) (c == ' ' || c == '\t' || c == '\n')
-
-#define IDENTIFIER_START(c) (LETTER(c)                                       \
-	|| c == '!' || c == '#' || c == '$'  || c == '%' || c == '&'         \
-	|| c == '*' || c == '+' || c == ','  || c == '-' || c == '.'         \
-	|| c == '/' || c == ';' || c == '<'  || c == '=' || c == '>'         \
-	|| c == '?' || c == '@' || c == '\\' || c == '^' || c == '|'         \
-	|| c == '~')
-
-#define IDENTIFIER_CONT(c) (IDENTIFIER_START(c) || DIGIT(c) || c == '\'')
+#define IDENTIFIER_CONT(c) (IDENTIFIER_START(c) || isdigit(c) || c == '\'')
 
 /*//////////////////////////////////////////////////////////////////////////*/
 
@@ -94,7 +84,7 @@ void consume_leading (char **next)
 	char *c = *next;
 
 	while (*c != 0) {
-		if (WHITESPACE(*c)) {
+		if (isspace(*c)) {
 			c++;
 		} else if (c[0] == '-' && c[1] == '-') {
 			while (*c != '\n' && *c != 0)
@@ -122,7 +112,7 @@ skO *parse_number (char **next)
 		return NULL;
 
 	while (1) {
-		if (DIGIT(*c)) {
+		if (isdigit(*c)) {
 			buffer[i] = *c;
 			i++;
 			c++;
@@ -137,7 +127,7 @@ skO *parse_number (char **next)
 		c++;
 
 		while (1) {
-			if (DIGIT(*c)) {
+			if (isdigit(*c)) {
 				buffer[i] = *c;
 				i++;
 				c++;

--- a/parser.c
+++ b/parser.c
@@ -164,7 +164,7 @@ skO *parse_character (char **next, jmp_buf jmp)
 			*next = c;
 			return skO_character_new('\n');
 		} else {
-			FATAL("PANIC! Unknown escape sequence.\n");
+			FATAL("PANIC! Unknown escape sequence \\%c.\n", *c);
 			longjmp(jmp, 1);
 		}
 	} else {
@@ -345,7 +345,7 @@ skO *parse_string (char **next, jmp_buf jmp)
 				sk_list_append(list, skO_character_new('\n'));
 				break;
 			default:
-				FATAL("PANIC! Unknown escape sequence.\n");
+				FATAL("PANIC! Unknown escape sequence \\%c.\n", *c);
 				longjmp(jmp, 1);
 			}
 		} else {

--- a/parser.c
+++ b/parser.c
@@ -112,13 +112,11 @@ skO *parse_number (char **next)
 		return NULL;
 
 	while (1) {
-		if (isdigit(*c)) {
-			buffer[i] = *c;
-			i++;
-			c++;
-		} else {
+		if (!isdigit(*c))
 			break;
-		}
+		buffer[i] = *c;
+		i++;
+		c++;
 	}
 
 	if (*c == '.') {
@@ -127,28 +125,24 @@ skO *parse_number (char **next)
 		c++;
 
 		while (1) {
-			if (isdigit(*c)) {
-				buffer[i] = *c;
-				i++;
-				c++;
-			} else {
+			if (!isdigit(*c))
 				break;
-			}
+			buffer[i] = *c;
+			i++;
+			c++;
 		}
 	}
 
 	buffer[i] = 0;
 
-	if (i) {
-		char **dummy = NULL;
-		*next = c;
-		#ifdef SK_PARSER_DEBUG
-		printf("Parsed NUMBER:      %s\n", buffer);
-		#endif
-		return skO_number_new(strtod(buffer, dummy));
-	} else {
+	if (!i)
 		return NULL;
-	}
+	char **dummy = NULL;
+	*next = c;
+	#ifdef SK_PARSER_DEBUG
+	printf("Parsed NUMBER:      %s\n", buffer);
+	#endif
+	return skO_number_new(strtod(buffer, dummy));
 }
 
 skO *parse_character (char **next, jmp_buf jmp)
@@ -195,13 +189,12 @@ skO *parse_qidentifier (char **next)
 
 	c++;
 
-	if (IDENTIFIER_START(*c)) {
-		buffer[i] = *c;
-		i++;
-		c++;
-	} else {
+	if (!IDENTIFIER_START(*c))
 		goto failure;
-	}
+
+	buffer[i] = *c;
+	i++;
+	c++;
 
 	while (1) {
 		if (c[0] == '-' && c[1] == '-')
@@ -233,13 +226,12 @@ skO *parse_identifier (char **next)
 	char buffer[SYMBOL_MAX_LENGTH];
 	short i = 0;
 
-	if (IDENTIFIER_START(*c)) {
-		buffer[i] = *c;
-		i++;
-		c++;
-	} else {
+	if (!IDENTIFIER_START(*c))
 		goto failure;
-	}
+
+	buffer[i] = *c;
+	i++;
+	c++;
 
 	while (1) {
 		if (c[0] == '-' && c[1] == '-')
@@ -389,20 +381,16 @@ skO *skO_parse (char **next, jmp_buf jmp, char *delim)
 	}
 
 	if (delim) {
-		if (*src == delim[0]) {
-			src++;
-			consume_leading(&src);
-			#ifdef SK_PARSER_DEBUG
-			printf("Parsed %c\n", delim[0]);
-			#endif
-		} else {
+		if (*src != delim[0])
 			return NULL;
-		}
-	} else {
-		if (*src == 0) {
-			ended = 1;
-			exit(EXIT_FAILURE);
-		}
+		src++;
+		consume_leading(&src);
+		#ifdef SK_PARSER_DEBUG
+		printf("Parsed %c\n", delim[0]);
+		#endif
+	} else if (*src == 0) {
+		ended = 1;
+		exit(EXIT_FAILURE);
 	}
 
 	while (!ended) {

--- a/parser.c
+++ b/parser.c
@@ -167,14 +167,32 @@ skO *parse_character (char **next, jmp_buf jmp)
 		case '\\':
 			result = '\\';
 			break;
+		case '"':
+			result = '"';
+			break;
+		case 'a':
+			result = '\a';
+			break;
+		case 'b':
+			result = '\b';
+			break;
+		case 'f':
+			result = '\f';
+			break;
 		case 'n':
 			result = '\n';
+			break;
+		case 'r':
+			result = '\r';
 			break;
 		case 's':
 			result = ' ';
 			break;
 		case 't':
 			result = '\t';
+			break;
+		case 'v':
+			result = '\v';
 			break;
 		default:
 			FATAL("PANIC! Unknown escape sequence \\%c.\n", *c);

--- a/parser.c
+++ b/parser.c
@@ -458,23 +458,13 @@ skO *skO_parse (char **next, jmp_buf jmp, char *delim)
 
 		/* Handle regular tokens. */
 
-		obj = parse_string(&src, pe);
-		if (obj != NULL) goto matched;
-
-		obj = parse_number(&src);
-		if (obj != NULL) goto matched;
-
-		obj = parse_qidentifier(&src);
-		if (obj != NULL) goto matched;
-
-		obj = parse_identifier(&src);
-		if (obj != NULL) goto matched;
-
-		obj = parse_character(&src, pe);
-		if (obj != NULL) goto matched;
-
-		obj = skO_parse(&src, pe, "[]");
-		if (obj != NULL) goto matched;
+		if ((obj = parse_string(&src, pe))
+			|| (obj = parse_number(&src))
+			|| (obj = parse_qidentifier(&src))
+			|| (obj = parse_identifier(&src))
+			|| (obj = parse_character(&src, pe))
+			|| (obj = skO_parse(&src, pe, "[]")))
+			goto matched;
 
 		/* If everything failed... */
 

--- a/parser.c
+++ b/parser.c
@@ -488,7 +488,7 @@ skO *skO_parse (char **next, jmp_buf jmp, char *delim)
 
 		/* If everything failed... */
 
-		printf("PANIC! Parsing error: %s\n", src);
+		fprintf(stderr, "PANIC! Parsing error: %s\n", src);
 		longjmp(jmp, 1);
 
 	matched:

--- a/parser.c
+++ b/parser.c
@@ -275,7 +275,7 @@ skO *parse_op_def (char **next)
 		src++;
 		consume_leading(&src);
 		sym = parse_identifier(&src);
-		if (sym != NULL) {
+		if (sym) {
 			*next = src;
 			sym->tag = SKO_QSYMBOL;
 			#ifdef SK_PARSER_DEBUG
@@ -298,7 +298,7 @@ skO *parse_obj_reserve (char **next)
 		src++;
 		consume_leading(&src);
 		sym = parse_identifier(&src);
-		if (sym != NULL) {
+		if (sym) {
 			*next = src;
 			sym->tag = SKO_QSYMBOL;
 			#ifdef SK_PARSER_DEBUG
@@ -321,7 +321,7 @@ skO *parse_obj_restore (char **next)
 		src++;
 		consume_leading(&src);
 		sym = parse_identifier(&src);
-		if (sym != NULL) {
+		if (sym) {
 			*next = src;
 			sym->tag = SKO_QSYMBOL;
 			#ifdef SK_PARSER_DEBUG
@@ -382,18 +382,13 @@ skO *skO_parse (char **next, jmp_buf jmp, char *delim)
 	consume_leading(&src);
 
 	if (setjmp(pe)) {
-		if (prefixed != NULL)
+		if (prefixed)
 			free(prefixed);
 		skO_free(list);
 		printf("parse jmp\n");
 	}
 
-	if (delim == NULL) {
-		if (*src == 0) {
-			ended = 1;
-			exit(EXIT_FAILURE);
-		}
-	} else {
+	if (delim) {
 		if (*src == delim[0]) {
 			src++;
 			consume_leading(&src);
@@ -402,6 +397,11 @@ skO *skO_parse (char **next, jmp_buf jmp, char *delim)
 			#endif
 		} else {
 			return NULL;
+		}
+	} else {
+		if (*src == 0) {
+			ended = 1;
+			exit(EXIT_FAILURE);
 		}
 	}
 
@@ -416,7 +416,7 @@ skO *skO_parse (char **next, jmp_buf jmp, char *delim)
 
 		/* Handle end of lists and prefixed syntax. */
 
-		if (delim != NULL) {
+		if (delim) {
 			if (*src == delim[1]) {
 				src++;
 				*next = src;
@@ -430,27 +430,27 @@ skO *skO_parse (char **next, jmp_buf jmp, char *delim)
 		/* Handle "prefix style" syntactic sugar. */
 
 		prefixed = skO_parse(&src, pe, "()");
-		if (prefixed != NULL)
+		if (prefixed)
 			consume_leading(&src);
 
 		/* Handle "reserving operations" syntactic sugar. */
 
 		obj = parse_op_def(&src);
-		if (obj != NULL) {
+		if (obj) {
 			sk_list_append(list, obj);
 			obj = skO_symbol_new("$=>");
 			goto matched;
 		}
 
 		obj = parse_obj_reserve(&src);
-		if (obj != NULL) {
+		if (obj) {
 			sk_list_append(list, obj);
 			obj = skO_symbol_new("$->");
 			goto matched;
 		}
 
 		obj = parse_obj_restore(&src);
-		if (obj != NULL) {
+		if (obj) {
 			sk_list_append(list, obj);
 			obj = skO_symbol_new("$<-");
 			goto matched;
@@ -474,7 +474,7 @@ skO *skO_parse (char **next, jmp_buf jmp, char *delim)
 	matched:
 		sk_list_append(list, obj);
 		
-		if (prefixed != NULL) {
+		if (prefixed) {
 			sk_list_append(list, prefixed->data.list);
 			free(prefixed);
 			prefixed = NULL;

--- a/shirka.c
+++ b/shirka.c
@@ -28,7 +28,7 @@ int main (int argc, char const *argv[])
 	ast = skO_loadParse((char *)argv[1]);
 	skE_execList(env, ast, 1);
 
-	if (env->stack != NULL)
+	if (env->stack)
 		printf("WARNING! Stack non empty upon exit.\n");
 
 	if (env->panic) {


### PR DESCRIPTION
I tried to clean up a few small issues. Some things are stylistic; just ignore them if you disagree. I tried to keep the commits as separate as possible, so feel free to `git cherry-pick` whatever you like. Highlights:
- Errors are reported on `stderr` instead of `stdout`.
- Some error messages include more information.
- The character escapes mentioned in [Data-types](https://github.com/hashmal/shirka/wiki/Data-types) are now included.
